### PR TITLE
Trim down the text emoji regex size

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -1,4 +1,4 @@
 module.exports = () => {
 	// https://mathiasbynens.be/notes/es-unicode-property-escapes#emoji
-	return /<% emojiSequence %>|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji}/gu;
+	return /<% emojiSequence %>|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Emoji_Presentation}|\p{Emoji}\uFE0F?/gu;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -82,7 +82,14 @@ describe('Regex that includes emoji as their text representation', () => {
 	};
 
 	// Test a default text presentation character rendered as emoji.
+	// Hardcoded tests just to be safe, repeated by the scripted loop below.
 	test('\u{2194}');
 	test('\u{1F321}');
+
+	// Test `Emoji` symbols.
+	const Emoji = require('unicode-tr51/Emoji.js');
+	for (const codePoint of Emoji) {
+		test(String.fromCodePoint(codePoint));
+	}
 
 });


### PR DESCRIPTION
I noticed the text emoji regex was using an inefficient method of optionally matching the variation selector `\uFE0F` after `\p{Emoji}`. Due to all the character class expansions, this ends up bloating the generated regex with duplicate paths. Switching the match to just make `\uFE0F` optional brings down the size of the generated regex considerably:

```js
> require('./text-old')().source.length
8474
> require('./text-new')().source.length
7093
```

I also added a looped test for all the `\p{Emoji}` characters to verify it still matches everything correctly.