### PR TITLE
Update regexgen to v1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-transform-unicode-property-regex": "^2.0.1",
     "babel-preset-env": "^1.2.2",
     "mocha": "^3.2.0",
-    "regexgen": "^1.2.3",
+    "regexgen": "^1.2.4",
     "unicode-tr51": "^8.1.1"
   }
 }

--- a/script/inject-sequences.js
+++ b/script/inject-sequences.js
@@ -2,11 +2,10 @@ const fs = require('fs');
 
 const Trie = require('regexgen').Trie;
 const sequences = require('unicode-tr51/sequences.js');
+sequences.sort((a, b) => b.length - a.length);
 
 const trie = new Trie();
-for (const sequence of sequences) {
-	trie.add(sequence);
-}
+trie.addAll(sequences);
 const sequencePattern = trie.toString();
 console.log(sequencePattern);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -70,6 +70,12 @@ describe('Emoji regex', () => {
 	// Test a ZWJ emoji sequence (`emoji-zwj-sequences.txt`).
 	test('\u{1F3CA}\u{1F3FD}\u200D\u2640\uFE0F');
 
+	// Test all emoji sequences
+	const sequences = require('unicode-tr51/sequences.js');
+	for (const sequence of sequences) {
+		test(sequence);
+	}
+
 });
 
 describe('Regex that includes emoji as their text representation', () => {


### PR DESCRIPTION
This is the fix for #16, which turned out to have 2 root causes:

1. `regexgen` had a bug that resulted in nested alternations not being correctly sorted by length (fixed in devongovett/regexgen#16).
2. Due to the way `regexgen` builds and simplifies its internal representation, I've found that it optimises better when the inputs are provided in order from longest to shortest. As such, sorting the `sequences` list by length before passing it into the `Trie` class produces a regex that correctly matches longer sequences before shorter ones.

Interestingly, fixing #16 required both of the points above to be tackled at the same time. Adding a test for every sequence produced the following results:

| Scenario | Test failures |
|----------|---------------|
| No change (i.e. the bug reported in #16) | 86 |
| Pre-sorting sequences, `regexgen` unchanged | 92 |
| `regexgen` bug fix, no pre-sorting | 80 |
| `regexgen` bug fix plus pre-sorting (this PR) | **0** |
