### PR TITLE
Provide correct export types for CJS module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,23 @@
 declare module 'emoji-regex' {
     function emojiRegex(): RegExp;
 
-    export default emojiRegex;
+    export = emojiRegex;
 }
 
 declare module 'emoji-regex/text' {
     function emojiRegex(): RegExp;
 
-    export default emojiRegex;
+    export = emojiRegex;
 }
 
 declare module 'emoji-regex/es2015' {
     function emojiRegex(): RegExp;
 
-    export default emojiRegex;
+    export = emojiRegex;
 }
 
 declare module 'emoji-regex/es2015/text' {
     function emojiRegex(): RegExp;
 
-    export default emojiRegex;
+    export = emojiRegex;
 }


### PR DESCRIPTION
Since module export format is CJS, TypeScript should be informed about the fact by using `export =` instead of `export default`.

`export default` is for ES modules, and when is used to declare exports of a CJS module (which doesn't have a "default" export) in a certain build/bundle config scenarios it can create a runtime bugs (Uncaught TypeError: es2015_1.default is not a function)