### PR TITLE
Limit NPM_TOKEN dependency to `publish` command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{README.md,package.json,.babelrc,.travis.yml}]
+[{README.md,package.json,.babelrc,*.yml}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -18,4 +18,6 @@ jobs:
       - name: Publish
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'
         run: npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://wombat-dressing-room.appspot.com/
-//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Maintainers using e.g. `npm version` or `npm install` shouldn’t have to set a dummy environment variable before being able to run their command. This patch makes it so.