### PR TITLE
Reintroduce changes from #78, #79 (missing RGI_Emoji.d.ts) previously removed by force push

### DIFF
--- a/RGI_Emoji.d.ts
+++ b/RGI_Emoji.d.ts
@@ -1,4 +1,4 @@
-declare module 'emoji-regex' {
+declare module 'emoji-regex/RGI_Emoji' {
     function emojiRegex(): RegExp;
 
     export = emojiRegex;

--- a/es2015/RGI_Emoji.d.ts
+++ b/es2015/RGI_Emoji.d.ts
@@ -1,4 +1,4 @@
-declare module 'emoji-regex' {
+declare module 'emoji-regex/es2015/RGI_Emoji' {
     function emojiRegex(): RegExp;
 
     export = emojiRegex;

--- a/es2015/index.d.ts
+++ b/es2015/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'emoji-regex' {
+declare module 'emoji-regex/es2015' {
     function emojiRegex(): RegExp;
 
     export = emojiRegex;

--- a/es2015/text.d.ts
+++ b/es2015/text.d.ts
@@ -1,4 +1,4 @@
-declare module 'emoji-regex' {
+declare module 'emoji-regex/es2015/text' {
     function emojiRegex(): RegExp;
 
     export = emojiRegex;

--- a/es2015_types/RGI_Emoji.d.ts
+++ b/es2015_types/RGI_Emoji.d.ts
@@ -1,0 +1,5 @@
+declare module 'emoji-regex/es2015/RGI_Emoji' {
+    function emojiRegex(): RegExp;
+
+    export = emojiRegex;
+}

--- a/es2015_types/index.d.ts
+++ b/es2015_types/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'emoji-regex/es2015' {
+    function emojiRegex(): RegExp;
+
+    export = emojiRegex;
+}

--- a/es2015_types/text.d.ts
+++ b/es2015_types/text.d.ts
@@ -1,0 +1,5 @@
+declare module 'emoji-regex/es2015/text' {
+    function emojiRegex(): RegExp;
+
+    export = emojiRegex;
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "es2015"
   ],
   "scripts": {
-    "build": "rm -rf -- es2015; babel src -d .; NODE_ENV=es2015 babel src -d ./es2015; node script/inject-sequences.js",
+    "build": "rm -rf -- es2015; babel src -d .; NODE_ENV=es2015 babel src es2015_types -D -d ./es2015; node script/inject-sequences.js",
     "test": "mocha",
     "test:watch": "npm run test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "index.js",
     "index.d.ts",
     "RGI_Emoji.js",
+    "RGI_Emoji.d.ts",
     "text.js",
-    "es2015/index.js",
-    "es2015/RGI_Emoji.js",
-    "es2015/text.js"
+    "text.d.ts",
+    "es2015"
   ],
   "scripts": {
     "build": "rm -rf -- es2015; babel src -d .; NODE_ENV=es2015 babel src -d ./es2015; node script/inject-sequences.js",

--- a/text.d.ts
+++ b/text.d.ts
@@ -1,4 +1,4 @@
-declare module 'emoji-regex' {
+declare module 'emoji-regex/text' {
     function emojiRegex(): RegExp;
 
     export = emojiRegex;


### PR DESCRIPTION
It appears that a force push in the main repo (presumably accidentally) removed the merged commits for #78 and #79 from the main branch. This PR reintroduces the changes from those PRs (as new cherry-picked commits, since the merged commits are now orphaned and don't exist in a new clone).

The force push can be seen in the history of #81:
![image](https://user-images.githubusercontent.com/3347176/107715506-49870380-6c84-11eb-82b3-9e5c95729f3e.png)