### PR TITLE
feat:compatible to es5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-module.exports = () => {
+module.exports = function emojiRegex() {
 	// https://mths.be/emoji
 	return /<% pattern %>/g;
 };


### PR DESCRIPTION
Maybe we can change the arrow function to a normal function definition，so that we can use this package normally without compiling even in low-end browsers。yes, I used this package in webpack2, and finally compiled an error because the uglify plugin does not support es6