### PR TITLE
upgrade emoji-test-regex-pattern to v1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@unicode/unicode-14.0.0": "^1.2.1",
-    "emoji-test-regex-pattern": "^1.5.0",
+    "emoji-test-regex-pattern": "^1.7.2",
     "mocha": "^9.1.2"
   }
 }


### PR DESCRIPTION
https://github.com/mathiasbynens/emoji-regex/issues/61 reproduced on macOS and iOS.
This issue has been resolved in emoji-test-regex-pattern@1.7.2. https://github.com/mathiasbynens/emoji-test-regex-pattern/pull/19