### PR TITLE
"index.mjs" should be part of files list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "files": [
     "LICENSE-MIT.txt",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "index.mjs"
   ],
   "scripts": {
     "build": "node script/build.js",


### PR DESCRIPTION
This resolve the installtion issues due to incorrect module exports specified in its package.json.